### PR TITLE
Update app.json.ejs for Expo SDK 25

### DIFF
--- a/boilerplate/app.json.ejs
+++ b/boilerplate/app.json.ejs
@@ -4,7 +4,7 @@
     "description": "No description",
     "slug": "<%= props.name %>",
     "privacy": "public",
-    "sdkVersion": "23.0.0",
+    "sdkVersion": "25.0.0",
     "version": "1.0.0",
     "orientation": "portrait",
     "primaryColor": "#cccccc",


### PR DESCRIPTION
Tried to clean install with `ignite new Test -b ignite-expo` today, and had a React Native version mismatch error, along the lines of [this](https://github.com/expo/expo/issues/923). Since I saw that the boilerplate was updated to Expo SDK 25 recently, all I had to do to fix it was update `app.json` from SDK 23 to 25. Hopefully this helps.